### PR TITLE
Update podcast-index-stats-visualized.md

### DIFF
--- a/content/posts/podcast-index-stats-visualized.md
+++ b/content/posts/podcast-index-stats-visualized.md
@@ -4,8 +4,6 @@ description: "Visualizing the podcast data provided daily by podcastindex.org"
 slug: "podcast-index-stats-visualized"
 images:
 - podcast-index-stats.png
-date: 2022-12-03T15:42:00-06:00
-lastmod: 2022-12-03T15:42:00-06:00
 draft: false
 ---
 


### PR DESCRIPTION
Removing the incorrect publish dates from the front matter. The correct date is "today" - not a date in December in 2022!