### PR TITLE
Hiding erroneous pubdate

### DIFF
--- a/content/posts/archive/podcast-cdns-by-episode-share-2024-01.md
+++ b/content/posts/archive/podcast-cdns-by-episode-share-2024-01.md
@@ -4,8 +4,8 @@ description: "Ranked list of podcast CDNs (content delivery networks), based on 
 slug: "archive/podcast-cdns-by-episode-share-january-2024"
 images:
 - cdns-2024-01.png
-date: 2024-02-02T15:41:00-06:0
-lastmod: 2024-02-02T15:41:00-06:0
+date: 2024-02-02T15:41:00-06:00
+lastmod: 2024-02-02T15:41:00-06:00
 draft: false
 rssrevision: 2024-01
 tags:

--- a/content/posts/podcast-index-stats-visualized.md
+++ b/content/posts/podcast-index-stats-visualized.md
@@ -6,6 +6,7 @@ images:
 - podcast-index-stats.png
 date: 2022-12-03T15:42:00-06:00
 lastmod: 2022-12-03T15:42:00-06:00
+updatefrequency: daily
 draft: false
 ---
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,7 @@
     <header id="post-header">
         <h1>{{ .Title }}</h1>
 		{{- if .Param "updatefrequency" -}}
-			<!-- if there is an updatefrequency in the front matter, this writes a semantically correct pubdate but shows a message that it's updated on a daily basis -->
+			<!-- if there is an updatefrequency in the front matter, this writes a semantically correct pubdate but shows a message that it's updated on a (whatever) basis -->
 			<time pubdate {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>This page is updated {{ .Param "updatefrequency" }}</time>
 		{{- else if isset .Params "date" -}}
 			<!-- else, we will show the actual date this page was last updated -->

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+<article>
+    <header id="post-header">
+        <h1>{{ .Title }}</h1>
+		{{- if .Param "updatefrequency" -}}
+			<!-- if there is an updatefrequency in the front matter, this writes a semantically correct pubdate but shows a message that it's updated on a daily basis -->
+			<time pubdate {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>This page is updated {{ .Param "updatefrequency" }}</time>
+		{{- else if isset .Params "date" -}}
+			<!-- else, we will show the actual date this page was last updated -->
+            <time pubdate {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>{{ .Date.Format "January 2, 2006" }}</time>
+        {{- end -}}
+    </header>
+    {{- .Content -}}
+</article>
+{{ end }}


### PR DESCRIPTION
A new frontmatter param of "updatefrequency" allows you to override the visible pubdate with a note that "this is updated (%updatefrequency%)" in the date section instead. Allows this sort of thing, thus communicating that this page is continually updated. The pubdate in metadata is unaffected.

<img width="623" alt="Screenshot 2024-12-31 at 10 55 01 am" src="https://github.com/user-attachments/assets/f13ad1a5-4677-4731-84a5-d532db71a108" />

Also, corrected an archive date that caused Hugo to fail a site build.